### PR TITLE
pivotaltracker: Auto-deliver labeled stories

### DIFF
--- a/config/default.coffee
+++ b/config/default.coffee
@@ -33,3 +33,8 @@ module.exports =
       noTestingLabel: 'no qa'
       testingPassedLabel: 'qa+'
       testingFailedLabel: 'qa-'
+      autoDeliverLabels: do ->
+        if process.env.AUTODELIVER_LABELS?
+          _.compact(process.env.AUTODELIVER_LABELS?.split(','))
+        else
+          ['dupe', 'wontfix']

--- a/models/issuetrackers/pivotaltracker.spec.coffee
+++ b/models/issuetrackers/pivotaltracker.spec.coffee
@@ -490,3 +490,50 @@ review 34567 is pending ([link](https://review.salsitasoft.com/r/34567))
 
       pt.tryFailTesting(event).then ->
         _client.updateStory.should.have.not.been.called
+
+  describe "tryAutoFinish", ->
+
+    it "delivers the story when it is labeled with an auto-finish label", ->
+      event = {
+        story: {
+          id: 1
+          projectId: 1
+          currentState: 'started'
+        }
+        original_labels: [
+          'foobar'
+        ]
+        new_labels: [
+          'foobar', 'wontfix'
+        ]
+      }
+
+      update = {
+        currentState: 'delivered'
+        labels: [{name: 'foobar'}]
+      }
+
+      _client.updateStory.returns(Q())
+
+      pt.tryAutoDeliver(event).then ->
+        _client.updateStory.should.have.been.calledWith(1, 1, update)
+
+    it "does not deliver the story when the conditions are not met", ->
+      event = {
+        story: {
+          id: 1
+          projectId: 1
+          currentState: 'started'
+        }
+        original_labels: [
+          'foobar',
+        ]
+        new_labels: [
+          'foobar', 'some-random-label'
+        ]
+      }
+
+      _client.updateStory.returns(Q())
+
+      pt.tryAutoDeliver(event).then ->
+        _client.updateStory.should.have.not.been.called


### PR DESCRIPTION
Stories labeled by default with 'dupe' and 'wontfix' are not
automatically moved into the delivered state so that it is not necessary
to review and QA the story. The client only needs to accept the story to
say that the way the story was closed was correct.

Change-Id: 6ff9039cc3

@realyze 
